### PR TITLE
Move the [user] section out of version control

### DIFF
--- a/config/.gitconfig
+++ b/config/.gitconfig
@@ -1,3 +1,8 @@
+[include]
+  # Includes need git 1.7.10 to work. Replace this with
+  # a [user] section if you don't have a up-to-date version
+  path = ~/.gitidentity
+
 [color]
   diff = auto
   status = auto
@@ -31,11 +36,6 @@
 
 [svn]
   followparent = true
-
-# Dear god, please change these if you borrow my gitconfig
-[user]
-#  name  = Replace with your name
-#  email = Replace with your email
 
 # Show a log of '56 minutes ago' rather than 'November 12, 2008 12:34:53'
 [log]

--- a/install_bashrc
+++ b/install_bashrc
@@ -30,3 +30,12 @@ if [ -e $HOME/.inputrc ]; then
   mv $HOME/.inputrc $HOME/.inputrc_backup
 fi;
 ln -s $INSTALL_DIR/config/.inputrc $HOME/.inputrc
+
+if [ ! -e $HOME/.gitidentity ]; then
+  echo "Setting up your git identity in ~/.gitidentity:"
+  echo -n "Email: "
+  read email
+  echo -n "Name: "
+  read name
+  echo -e "[user]\n\tname = $name\n\temail = $email" > $HOME/.gitidentity
+fi


### PR DESCRIPTION
I previously have issues with the [user] section, that causes troubles when having the configuration under version control and want to share with people.

The solution is to add an include of an external file with the identity details, so that file could be out of version control system.

I also tweaked the install so it asks for the identity details (name, email) during install if the identity file is not present.
