### PR TITLE
change git clone protocol from git:// to https://

### DIFF
--- a/README
+++ b/README
@@ -25,7 +25,7 @@ the context of that group.
 
 ==HOW TO INSTALL==
 cd ~
-git clone git://github.com/cep21/jackbash.git
+git clone https://github.com/cep21/jackbash.git
 cd jackbash
 ./install_bashrc
 cd ..

--- a/install_bashrc
+++ b/install_bashrc
@@ -7,7 +7,7 @@ if [ -d $INSTALL_DIR ]; then
   exit
 fi;
 
-git clone git://github.com/cep21/jackbash.git $INSTALL_DIR
+git clone https://github.com/cep21/jackbash.git $INSTALL_DIR
 
 for x in $HOME/.bashrc $HOME/.profile $HOME/.bash_profile ; do
   if [ -e $x ]; then


### PR DESCRIPTION
Support for the git:// protocol has been removed on GitHub. Updates git:// to https://

https://github.blog/2021-09-01-improving-git-protocol-security-github/